### PR TITLE
add shuffle option when playing directory.

### DIFF
--- a/lib/airplayer/app.rb
+++ b/lib/airplayer/app.rb
@@ -2,11 +2,12 @@ require 'thor'
 
 module AirPlayer
   class App < Thor
-    desc 'play <URI|FILE|DIR> [-r|--repeat] ', 'Play video(URI or local video file path or video directory)'
+    desc 'play <URI|FILE|DIR> [-r|--repeat] [-s|--shuffle]', 'Play video(URI or local video file path or video directory)'
     method_option :repeat, :aliases => '-r', :desc => 'Repeat play', :type => :boolean
+    method_option :shuffle, :aliases => '-s', :desc => 'Random play', :type => :boolean
     def play(target)
       controller = Controller.new
-      Playlist.new.add(target).entries(options.repeat) do |media|
+      Playlist.new.add(target, options.shuffle).entries(options.repeat) do |media|
         controller.play(media)
       end
     end

--- a/lib/airplayer/playlist.rb
+++ b/lib/airplayer/playlist.rb
@@ -1,8 +1,8 @@
 module AirPlayer
   class Playlist < Array
-    def add(item)
+    def add(item, shuffle = false)
       path = File.expand_path(item)
-      Dir.exists?(path) ? concat(media_in(path)) : push(Media.new(item))
+      Dir.exists?(path) ? concat(media_in(path, shuffle)) : push(Media.new(item))
       self
     end
 
@@ -14,8 +14,9 @@ module AirPlayer
     end
 
     private
-      def media_in(path)
-        Dir.entries(path).map do |node|
+      def media_in(path, shuffle = false)
+        medias = shuffle ? Dir.entries(path).shuffle! : Dir.entries(path)
+        medias.map do |node|
           media_path = File.expand_path(node, path)
           Media.new(media_path) if Media.playable? media_path
         end.compact


### PR DESCRIPTION
ディレクトリ内のファイルの再生順をシャッフルするオプションを追加しました。

Usage:

```
$ airplayer play /path/to/dir -s
```

or

```
$ airplayer play /path/to/dir --shuffle
```
