### PR TITLE
play の引数にディレクトリを指定した場合 sort する

### DIFF
--- a/lib/airplayer/playlist.rb
+++ b/lib/airplayer/playlist.rb
@@ -21,7 +21,7 @@ module AirPlayer
 
     private
       def media_in(path)
-        Dir.entries(path).map do |node|
+        Dir.entries(path).sort.map do |node|
           Media.new(File.expand_path(node, path)) if Media.playable? node
         end.compact
       end


### PR DESCRIPTION
> $ airplayer play /path/to/directory

とディレクトリを指定した場合に再生される順番を sort するようにしました
