### PR TITLE
プログレスバーが98%で止まって永遠にAirplayerが終了しない

### DIFF
--- a/lib/airplayer/controller.rb
+++ b/lib/airplayer/controller.rb
@@ -79,7 +79,7 @@ module AirPlayer
       end
 
       def progress?
-        0 < @current_sec && @current_sec < @total_sec
+        0 < @current_sec && @total_sec - @current_sec > 1
       end
   end
 end


### PR DESCRIPTION
Airplay の server が最終値の1秒前までしか position を返してくれないので
duration と position を比較して1秒前なら終了にした。
