### PR TITLE
Bugfix directory of Japanese name

### DIFF
--- a/lib/airplayer/media.rb
+++ b/lib/airplayer/media.rb
@@ -48,7 +48,7 @@ module AirPlayer
         return SUPPORTED_MIME_TYPES.include?(mimetype)
       end
 
-      host = URI.parse(path).host
+      host = URI.parse(URI.escape(path)).host
       SUPPORTED_DOMAINS.each do |domain|
         return true if host =~ /#{domain}/
       end

--- a/spec/airplayer/media_spec.rb
+++ b/spec/airplayer/media_spec.rb
@@ -19,6 +19,7 @@ module AirPlayer
         expect(subject.playable?('007 SKYFALL.flv')).to be_false
         expect(subject.playable?('007 SKYFALL.wmv')).to be_false
         expect(subject.playable?('.DS_Store')).to be_false
+        expect(subject.playable?('Fate_Kaleid_Liner_プリズマ☆イリヤ')).to be_false
       end
     end
 


### PR DESCRIPTION
directory list

``` sh
 $ ls -l
drwxrwxrwx 2 naoto naoto      4096  7月 18 23:07 Fate_Kaleid_Liner_プリズマ☆イリヤ
```

playing to shuffle

``` sh
 $ airplayer play ./ -s
/home/naoto/.rbenv/versions/2.0.0-p247/lib/ruby/2.0.0/uri/common.rb:176:in `split': bad URI(is not URI?): Fate_Kaleid_Liner_プリズマ☆イリヤ (URI::InvalidURIError)
        from /home/naoto/.rbenv/versions/2.0.0-p247/lib/ruby/2.0.0/uri/common.rb:211:in `parse'
        from /home/naoto/.rbenv/versions/2.0.0-p247/lib/ruby/2.0.0/uri/common.rb:747:in `parse'
        from /home/naoto/dev/airplayer/lib/airplayer/media.rb:51:in `playable?'
        from /home/naoto/dev/airplayer/lib/airplayer/playlist.rb:46:in `block in media_in_local'
        from /home/naoto/dev/airplayer/lib/airplayer/playlist.rb:45:in `map'
        from /home/naoto/dev/airplayer/lib/airplayer/playlist.rb:45:in `media_in_local'
        from /home/naoto/dev/airplayer/lib/airplayer/playlist.rb:16:in `add'
        from /home/naoto/dev/airplayer/lib/airplayer/app.rb:11:in `play'
        from /home/naoto/dev/airplayer/vendor/bundle/ruby/2.0.0/gems/thor-0.18.1/lib/thor/command.rb:27:in `run'
        from /home/naoto/dev/airplayer/vendor/bundle/ruby/2.0.0/gems/thor-0.18.1/lib/thor/invocation.rb:120:in `invoke_command'
        from /home/naoto/dev/airplayer/vendor/bundle/ruby/2.0.0/gems/thor-0.18.1/lib/thor.rb:363:in `dispatch'
        from /home/naoto/dev/airplayer/vendor/bundle/ruby/2.0.0/gems/thor-0.18.1/lib/thor/base.rb:439:in `start'
        from bin/airplayer:5:in `<main>'
```
