### PR TITLE
Use builtin RSS::Parser instead of Nokogiri

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,6 @@ PATH
       airplay (~> 1.0.2)
       http (~> 0.5.0)
       mime-types (= 2.0)
-      nokogiri
       rack
       reel (~> 0.4.0)
       reel-rack (~> 0.1.0)
@@ -69,7 +68,6 @@ GEM
     method_source (0.8.2)
     micromachine (1.0.4)
     mime-types (2.0)
-    mini_portile (0.5.3)
     multi_json (1.10.0)
     net-http-digest_auth (1.2.1)
     net-ptth (0.0.17)
@@ -77,8 +75,6 @@ GEM
       http_parser.rb (>= 0.6.0.beta.2)
       rack (>= 1.4.5)
     nio4r (1.0.0)
-    nokogiri (1.6.1)
-      mini_portile (~> 0.5.0)
     pry (0.9.12.6)
       coderay (~> 1.0)
       method_source (~> 0.8)

--- a/airplayer.gemspec
+++ b/airplayer.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'reel-rack', '~> 0.1.0'
   spec.add_runtime_dependency 'airplay', '~> 1.0.2'
   spec.add_runtime_dependency 'mime-types', '= 2.0'
-  spec.add_runtime_dependency 'nokogiri'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'

--- a/lib/airplayer/playlist.rb
+++ b/lib/airplayer/playlist.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 require 'rss'
-require 'nokogiri'
 
 module AirPlayer
   class Playlist < Array
@@ -36,7 +35,7 @@ module AirPlayer
           :local_dir
         elsif Media.playable? item
           :url
-        elsif RSS::Parser.parse(open(item))
+        elsif item.match(/.+(xml|rss)$/)
           :podcast
         end
       end
@@ -48,8 +47,8 @@ module AirPlayer
       end
 
       def media_in_podcast(path)
-        Nokogiri::XML(open(path)).search('enclosure').map do |node|
-          Media.new(node.attributes['url'].text)
+        RSS::Parser.parse(path).items.map do |node|
+          Media.new(node.link)
         end
       end
   end


### PR DESCRIPTION
I've removed the Nokogiri gem, So airplayer becomes easy to install on low spec device, like a raspberry pi.
