### PR TITLE
Limit ruby versions based on the OS X build environment by Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ sudo: false
 language: objective-c
 rvm:
   - 1.9.3
-  - 2.1.5
-  - 2.2.2
+  - 2.1.3
 
 cache: bundler
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: false
-language: ruby
+language: objective-c
 rvm:
   - 1.9.3
   - 2.1.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,17 @@
+sudo: false
 language: ruby
 rvm:
   - 1.9.3
   - 2.1.5
-  - 2.2.0
-  - 2.2.1
-
-env:
-  YOUTUBE_DL_VERSION=2015.04.03
+  - 2.2.2
 
 cache: bundler
 
+os:
+  - osx
+
 before_install:
-  - sudo apt-get -qq update
-  - sudo apt-get -qq install rdnssd libavahi-compat-libdnssd-dev
-  - sudo curl https://yt-dl.org/downloads/${YOUTUBE_DL_VERSION}/youtube-dl -o /usr/local/bin/youtube-dl
-  - sudo chmod a+x /usr/local/bin/youtube-dl
+  - brew install youtube-dl
 
 before_script:
   - which youtube-dl


### PR DESCRIPTION
The OS X Build Environment - Travis CI
http://docs.travis-ci.com/user/osx-ci-environment/

Travis CI's OS X build environment supporting Ruby versions:

- 1.9.3
- 2.0.0(default)
- 2.1.2
- 2.1.3

So I choose 1.9.3 and 2.1.3 for testing.